### PR TITLE
CASMPET-5217 Update to use latest strimzi

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2020] Hewlett Packard Enterprise Development LP
+(C) Copyright [2021] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/charts/cray-shared-kafka/Chart.yaml
+++ b/charts/cray-shared-kafka/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: cray-shared-kafka
-version: 0.6.0
+version: 1.0.0
 description: Shared Kafka cluster for systems management services.
 keywords:
   - cray-shared-kafka
 home: https://github.com/Cray-HPE/cray-shared-kafka
 maintainers:
   - name: bklei
-appVersion: 2.2.1  # Tracks Kafka version
+appVersion: 2.8.1 # Tracks Kafka version
 annotations:
   artifacthub.io/changes: |
     - kind: security

--- a/charts/cray-shared-kafka/templates/kafka.yaml
+++ b/charts/cray-shared-kafka/templates/kafka.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: {{ template "cray-shared-kafka.fullname" . }}
@@ -7,11 +7,13 @@ metadata:
 {{ include "cray-shared-kafka.labels" . | indent 4 }}
 spec:
   kafka:
-    version: 2.2.1
+    version: 2.8.1
     replicas: {{ .Values.kafka.replicas }}
     listeners:
-      plain: {}
-      #tls: {}
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
@@ -20,9 +22,7 @@ spec:
     storage:
       type: persistent-claim
       size: 10Gi
-      #class: ceph-rbd-external
       deleteClaim: false
-    metrics: {}
     template:
       pod:
         metadata:
@@ -40,12 +40,12 @@ spec:
       {{ toYaml . | nindent 6 }}
 {{- end }}
 {{- with .Values.kafka.clientsCA }}
-    clientsCA:
-      {{ toYaml . | nindent 6 }}
+  clientsCa:
+    {{ toYaml . | nindent 6 }}
 {{- end }}
 {{- with .Values.kafka.clusterCA }}
-    clusterCA:
-      {{ toYaml . | nindent 6 }}
+  clusterCa:
+    {{ toYaml . | nindent 6 }}
 {{- end }}
   zookeeper:
     replicas: 3

--- a/charts/cray-shared-kafka/templates/kafkatopics-cfs.yaml
+++ b/charts/cray-shared-kafka/templates/kafkatopics-cfs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:

--- a/charts/cray-shared-kafka/templates/kafkatopics-cfs.yaml
+++ b/charts/cray-shared-kafka/templates/kafkatopics-cfs.yaml
@@ -1,5 +1,5 @@
 # Copyright 2020 Hewlett Packard Enterprise Development LP
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: cfs-session-events

--- a/charts/cray-shared-kafka/templates/kafkatopics-hms.yaml
+++ b/charts/cray-shared-kafka/templates/kafkatopics-hms.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: cray-dmtf-resource-event


### PR DESCRIPTION
## Summary and Scope

Updates to use strimzi 0.27.0. This is being done to lower our CVE count and provide the proper CVE-2021-44228 fix.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5217](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5217)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? N, this jumps kafka from 2.2 to 2.8. I don't have any knowledge of how we test to validate that kafka can deal with the upgrade properly. This will need to be done on a bare metal system.
- Was downgrade tested? N, this jumps kafka from 2.2 to 2.8. I don't have any knowledge of how we test to validate that kafka can deal with the downgrade properly. This will need to be done on a bare metal system.
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

This bumps us from Kafka 2.2.1 to 2.8.1, which will need additional testing.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

