### PR TITLE
CASMPET-5323: Update cray-shared-kafka chart for CVE-2022-2330[257]

### DIFF
--- a/kubernetes/cray-shared-kafka/Chart.yaml
+++ b/kubernetes/cray-shared-kafka/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "2.2.1"
 description: Shared Kafka cluster for systems management services.
 name: cray-shared-kafka
-version: 0.5.0
+version: 0.6.0

--- a/kubernetes/cray-shared-kafka/templates/kafka.yaml
+++ b/kubernetes/cray-shared-kafka/templates/kafka.yaml
@@ -9,6 +9,8 @@ spec:
   kafka:
     version: 2.2.1
     replicas: {{ .Values.kafka.replicas }}
+    image: "{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}"
+    image: "{{ .Values.kafka.tlsSidecar.image.repository }}:{{ .Values.kafka.tlsSidecar.image.tag }}"
     listeners:
       plain: {}
       #tls: {}
@@ -49,6 +51,8 @@ spec:
 {{- end }}
   zookeeper:
     replicas: 3
+    image: "{{ .Values.zookeeper.image.repository }}:{{ .Values.zookeeper.image.tag }}"
+    image: "{{ .Values.zookeeper.tlsSidecar.image.repository }}:{{ .Values.zookeeper.tlsSidecar.image.tag }}"
     storage:
       type: persistent-claim
       size: 100Gi
@@ -71,6 +75,7 @@ spec:
           {{ toYaml . | nindent 6 }}
 {{- end }}
   entityOperator:
+    image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
     topicOperator: {}
     userOperator: {}
     template:

--- a/kubernetes/cray-shared-kafka/templates/kafka.yaml
+++ b/kubernetes/cray-shared-kafka/templates/kafka.yaml
@@ -10,7 +10,8 @@ spec:
     version: 2.2.1
     replicas: {{ .Values.kafka.replicas }}
     image: "{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}"
-    image: "{{ .Values.kafka.tlsSidecar.image.repository }}:{{ .Values.kafka.tlsSidecar.image.tag }}"
+    tlsSidecar:
+      image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
     listeners:
       plain: {}
       #tls: {}
@@ -52,7 +53,8 @@ spec:
   zookeeper:
     replicas: 3
     image: "{{ .Values.zookeeper.image.repository }}:{{ .Values.zookeeper.image.tag }}"
-    image: "{{ .Values.zookeeper.tlsSidecar.image.repository }}:{{ .Values.zookeeper.tlsSidecar.image.tag }}"
+    tlsSidecar:
+      image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
     storage:
       type: persistent-claim
       size: 100Gi
@@ -75,7 +77,8 @@ spec:
           {{ toYaml . | nindent 6 }}
 {{- end }}
   entityOperator:
-    image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
+    tlsSidecar:
+      image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
     topicOperator: {}
     userOperator: {}
     template:

--- a/kubernetes/cray-shared-kafka/values.yaml
+++ b/kubernetes/cray-shared-kafka/values.yaml
@@ -10,10 +10,6 @@ kafka:
   image:
     repository: strimzi/kafka
     tag: 0.15.0-kafka-2.2.1-noJSM-chainsaw
-  tlsSideCar:
-    image: 
-      repository: strimzi/kafka
-      tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
   clusterCA:
     generateCertificateAuthority: true
     validityDays: 730
@@ -29,10 +25,10 @@ kafka:
           podAffinityTerm:
             labelSelector:
               matchExpressions:
-              - key: strimzi.io/name
-                operator: In
-                values:
-                - cray-shared-kafka-kafka
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                    - cray-shared-kafka-kafka
             topologyKey: "kubernetes.io/hostname"
   resources:
     limits:
@@ -46,10 +42,6 @@ zookeeper:
   image:
     repository: strimzi/kafka
     tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
-  tlsSideCar:
-    image:
-      repository: strimzi/kafka
-      tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -57,10 +49,10 @@ zookeeper:
           podAffinityTerm:
             labelSelector:
               matchExpressions:
-              - key: strimzi.io/name
-                operator: In
-                values:
-                - cray-shared-kafka-zookeeper
+                - key: strimzi.io/name
+                  operator: In
+                  values:
+                    - cray-shared-kafka-zookeeper
             topologyKey: "kubernetes.io/hostname"
   resources:
     limits:
@@ -70,8 +62,7 @@ zookeeper:
       cpu: 10m
       memory: 64Mi
 
-entityOperator:
-  tlsSideCar:
-    image:
-      repository: strimzi/kafka
-      tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
+tlsSidecar:
+  image:
+    repository: strimzi/kafka
+    tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw

--- a/kubernetes/cray-shared-kafka/values.yaml
+++ b/kubernetes/cray-shared-kafka/values.yaml
@@ -7,6 +7,13 @@ fullnameOverride: ""
 
 kafka:
   replicas: 3
+  image:
+    repository: strimzi/kafka
+    tag: 0.15.0-kafka-2.2.1-noJSM-chainsaw
+  tlsSideCar:
+    image: 
+      repository: strimzi/kafka
+      tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
   clusterCA:
     generateCertificateAuthority: true
     validityDays: 730
@@ -36,6 +43,13 @@ kafka:
       memory: 64Mi
 
 zookeeper:
+  image:
+    repository: strimzi/kafka
+    tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
+  tlsSideCar:
+    image:
+      repository: strimzi/kafka
+      tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -55,3 +69,9 @@ zookeeper:
     requests:
       cpu: 10m
       memory: 64Mi
+
+entityOperator:
+  tlsSideCar:
+    image:
+      repository: strimzi/kafka
+      tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw


### PR DESCRIPTION
## Summary and Scope

Update cray-shared-kafka chart version and adding new image/tag references in the value.yaml for CVE-2022-2330[257]

## Issues and Related PRs

* Resolves [issue id](issue link):  [CASMPET-5323](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5323)
* Change will also be needed in `release/csm-1.0`

### Tested on:

  * Local development environment
  * Virtual Shasta


## Risks and Mitigations

NA

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
