### PR TITLE
CASMPET-5363 Disable custom image tag by default

### DIFF
--- a/charts/cray-shared-kafka/Chart.yaml
+++ b/charts/cray-shared-kafka/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "2.2.1"
 description: Shared Kafka cluster for systems management services.
 name: cray-shared-kafka
-version: 0.7.0
+version: 0.8.0

--- a/charts/cray-shared-kafka/templates/kafka.yaml
+++ b/charts/cray-shared-kafka/templates/kafka.yaml
@@ -9,9 +9,13 @@ spec:
   kafka:
     version: 2.2.1
     replicas: {{ .Values.kafka.replicas }}
+    {{- if .Values.kafka.image }}
     image: "{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}"
+    {{- end }}
+    {{- if .Values.tlsSidecar.image }}
     tlsSidecar:
       image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
+    {{- end }}
     listeners:
       plain: {}
       #tls: {}
@@ -52,9 +56,13 @@ spec:
 {{- end }}
   zookeeper:
     replicas: 3
+    {{- if .Values.zookeeper.image }}
     image: "{{ .Values.zookeeper.image.repository }}:{{ .Values.zookeeper.image.tag }}"
+    {{- end }}
+    {{- if .Values.tlsSidecar.image }}
     tlsSidecar:
       image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
+    {{- end }}
     storage:
       type: persistent-claim
       size: 100Gi
@@ -77,8 +85,10 @@ spec:
           {{ toYaml . | nindent 6 }}
 {{- end }}
   entityOperator:
+    {{- if .Values.tlsSidecar.image }}
     tlsSidecar:
       image: "{{ .Values.tlsSidecar.image.repository }}:{{ .Values.tlsSidecar.image.tag }}"
+    {{- end }}
     topicOperator: {}
     userOperator: {}
     template:

--- a/charts/cray-shared-kafka/values.yaml
+++ b/charts/cray-shared-kafka/values.yaml
@@ -8,8 +8,8 @@ fullnameOverride: ""
 kafka:
   replicas: 3
   image:
-    repository: strimzi/kafka
-    tag: 0.15.0-kafka-2.2.1-noJSM-chainsaw
+  #   repository:
+  #   tag:
   clusterCA:
     generateCertificateAuthority: true
     validityDays: 730
@@ -40,8 +40,8 @@ kafka:
 
 zookeeper:
   image:
-    repository: strimzi/kafka
-    tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
+  #   repository:
+  #   tag:
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -64,5 +64,5 @@ zookeeper:
 
 tlsSidecar:
   image:
-    repository: strimzi/kafka
-    tag: 0.15.0-kafka-2.3.1-noJSM-chainsaw
+  #   repository:
+  #   tag:


### PR DESCRIPTION
## Summary and Scope

We're setting the image tag changes via the strimzi operator and no longer need to set the image here. This is keeping the ability to change the image tag via a value in case its needed in the future.

## Issues and Related PRs

* Resolves [CASMPET-5363](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5363)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated the chart no longer overrode the image

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

