### PR TITLE
Casmpet 6936 upgrade change

### DIFF
--- a/charts/cray-shared-kafka/Chart.yaml
+++ b/charts/cray-shared-kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-shared-kafka
-version: 1.1.0
+version: 1.1.1
 description: Shared Kafka cluster for systems management services.
 keywords:
   - cray-shared-kafka

--- a/charts/cray-shared-kafka/templates/01-hook-serviceaccount.yaml
+++ b/charts/cray-shared-kafka/templates/01-hook-serviceaccount.yaml
@@ -1,0 +1,60 @@
+{{/*
+MIT License
+
+(C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-kafka-job-role
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - kafkatopics
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cray-kafka-job-rolebinding
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-kafka-job-role
+subjects:
+- kind: ServiceAccount
+  name: cray-shared-kafka-entity-operator
+  namespace: services

--- a/charts/cray-shared-kafka/templates/02-cleanup-upgrade-to-41.yaml
+++ b/charts/cray-shared-kafka/templates/02-cleanup-upgrade-to-41.yaml
@@ -1,0 +1,72 @@
+{{- /*
+MIT License
+
+(C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "cray-kafka-pre-upgrade-cleanup"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      name: "cray-kafka-pre-upgrade-cleanup"
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: "cray-shared-kafka-entity-operator"
+      restartPolicy: Never
+      containers:
+        - name: cray-kafka-pre-upgrade-cleanup
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+            - '/bin/sh'
+          args:
+            - "-c"
+            - |
+              echo "Cleaning up internal topics used by strimzi operator"
+              store_topic=$(kubectl get kt -n {{ .Values.namespace }} -o name | grep strimzi-store-topic)
+              if [ -n "$store_topic" ]; then
+                kubectl delete -n {{ .Values.namespace }} "$store_topic"
+              fi
+              topic_operator=$(kubectl get kt -n {{ .Values.namespace }} -o name | grep strimzi-topic-operator)
+              if [ -n "$topic_operator" ]; then
+                kubectl delete -n {{ .Values.namespace }} "$topic_operator"
+              fi
+              consumer_offset_topic=$(kubectl get kt -n {{ .Values.namespace }} -o name | grep consumer-offsets)
+              if [ -n "$consumer_offset_topic" ]; then
+                kubectl annotate -n {{ .Values.namespace }} "$consumer_offset_topic" strimzi.io/managed="false"
+                topic_json=$(kubectl get -n {{ .Values.namespace }} "$consumer_offset_topic" -o json)
+                while [ $(echo "$topic_json" | jq -r '.metadata.generation') != $(echo "$topic_json" | jq -r '.status.observedGeneration') ];
+                do
+                  echo "Waiting for reconciliation of strimzi operator internal topics ..."
+                  sleep 1
+                done;
+                kubectl delete -n {{ .Values.namespace }} "$consumer_offset_topic"
+              fi
+              echo "Internal topics deleted"

--- a/charts/cray-shared-kafka/templates/kafka.yaml
+++ b/charts/cray-shared-kafka/templates/kafka.yaml
@@ -18,7 +18,7 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "2.1"
+      log.message.format.version: "3.7"
     storage:
       type: persistent-claim
       size: 10Gi

--- a/charts/cray-shared-kafka/values.yaml
+++ b/charts/cray-shared-kafka/values.yaml
@@ -4,6 +4,7 @@
 
 nameOverride: ""
 fullnameOverride: ""
+namespace: "services"
 
 kafka:
   replicas: 3
@@ -55,3 +56,9 @@ zookeeper:
     requests:
       cpu: 10m
       memory: 64Mi
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.24.17
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

There are some kafka internal topics like consumer-offsets*/strimzi-store-topic*/strimzi-topic-operator*  which are used by topic operator for managing topics. But from strimzi version 0.39.0, the default mode of operator is changed from BTO to UTO. Because of this, the above internal topics are no longer needed. Adding a cleanup step to remove these before performing the upgrade. 
Ref - https://strimzi.io/docs/operators/0.41.0/deploying#upgrading_from_a_strimzi_version_using_the_bidirectional_topic_operator

## Issues and Related PRs

* Resolves [CASMPET-6936](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6936)

### Tested on:

  * starlord

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

