### PR TITLE
CASMPET-7382: Upgrade Kafka to v3.9

### DIFF
--- a/charts/cray-shared-kafka/Chart.yaml
+++ b/charts/cray-shared-kafka/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 name: cray-shared-kafka
-version: 1.1.1
+version: 1.2.0
 description: Shared Kafka cluster for systems management services.
 keywords:
   - cray-shared-kafka
 home: https://github.com/Cray-HPE/cray-shared-kafka
 maintainers:
   - name: bklei
-appVersion: 3.7.0  # Tracks Kafka version
+appVersion: 3.9.0  # Tracks Kafka version
 annotations:
   artifacthub.io/changes: |
     - kind: security

--- a/charts/cray-shared-kafka/templates/kafka.yaml
+++ b/charts/cray-shared-kafka/templates/kafka.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "cray-shared-kafka.labels" . | indent 4 }}
 spec:
   kafka:
-    version: 3.7.0
+    version: 3.9.0
     replicas: {{ .Values.kafka.replicas }}
     listeners:
       - name: plain
@@ -18,7 +18,7 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: "3.7"
+      log.message.format.version: "3.9"
     storage:
       type: persistent-claim
       size: 10Gi


### PR DESCRIPTION
## Summary and Scope

Upgrade Kafka version to 3.9 for CSM 1.7.

## Issues and Related PRs

* Related to [CASMPET-7382](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7382)
* Operator PR: https://github.com/Cray-HPE/cray-kafka-operator/pull/10
* Image PR: https://github.com/Cray-HPE/container-images/pull/666

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Previous image:
```
# kubectl describe deployment cray-shared-kafka-entity-operator -n services  | grep Image
    Image:      artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
    Image:      artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
# kubectl get crds | grep kafka.strimzi.io
kafkabridges.kafka.strimzi.io                         2025-02-06T21:00:26Z
kafkaconnectors.kafka.strimzi.io                      2025-02-06T21:00:26Z
kafkaconnects.kafka.strimzi.io                        2025-02-06T21:00:26Z
kafkamirrormaker2s.kafka.strimzi.io                   2025-02-06T21:00:26Z
kafkamirrormakers.kafka.strimzi.io                    2025-02-06T21:00:26Z
kafkanodepools.kafka.strimzi.io                       2025-02-06T21:00:26Z
kafkarebalances.kafka.strimzi.io                      2025-02-06T21:00:26Z
kafkas.kafka.strimzi.io                               2025-02-06T21:00:25Z
kafkatopics.kafka.strimzi.io                          2025-02-06T21:00:26Z
kafkausers.kafka.strimzi.io                           2025-02-06T21:00:26Z
```

All pods updated and using new images:
```
# kubectl get pods -A | grep strimzi
operators        strimzi-cluster-operator-6986698dc6-2ms4n                         1/1     Running            0                3m17s
# kubectl describe pod strimzi-cluster-operator-6986698dc6-2ms4n -n operators | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
# kubectl get pods -A | grep kafka
services         cray-shared-kafka-entity-operator-6fdb8685b6-kjkfd                2/2     Running            0                21s
services         cray-shared-kafka-kafka-0                                         1/1     Running            0                108s
services         cray-shared-kafka-kafka-1                                         1/1     Running            0                78s
services         cray-shared-kafka-kafka-2                                         1/1     Running            0                51s
services         cray-shared-kafka-zookeeper-0                                     1/1     Running            0                2m20s
services         cray-shared-kafka-zookeeper-1                                     1/1     Running            0                3m36s
services         cray-shared-kafka-zookeeper-2                                     1/1     Running            0                3m2s
# kubectl describe pod -n services cray-shared-kafka-entity-operator-6fdb8685b6-kjkfd | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
# kubectl describe pod cray-shared-kafka-kafka-0 -n services | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
# kubectl describe pod cray-shared-kafka-zookeeper-0 -n services | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
```

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

